### PR TITLE
chore: update requests to 2.33.1 for security vulnerability fix

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-03-13T13:19:28Z",
+  "generated_at": "2026-04-15T16:23:29Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests>=2.32.4,<3.0
+requests>=2.33.1,<3.0
 python_dateutil>=2.5.3,<3.0.0
 ibm_cloud_sdk_core>=3.8.0,<4.0.0


### PR DESCRIPTION
## Summary
Updates the requests library from minimum version 2.32.4 to 2.33.1 to address security vulnerabilities.

## Changes
- Updated `requirements.txt`: Changed `requests>=2.32.4,<3.0` to `requests>=2.33.1,<3.0`
- Updated `.secrets.baseline` from detect-secrets scan

## Testing
✅ All 268 unit tests passing
✅ Linter passing with 10.00/10 rating
✅ detect-secrets scan completed with no issues

## Security
This update addresses known security vulnerabilities in the requests library by updating to the latest stable version (2.33.1).